### PR TITLE
Add "dbg" to better understand system.file()

### DIFF
--- a/R/createFunctionExtdataFile.R
+++ b/R/createFunctionExtdataFile.R
@@ -10,10 +10,28 @@
 #' dir(extdataFile())
 createFunctionExtdataFile <- function(package)
 {
-  function(..., must_exist = TRUE) {
-    
-    extdata_dir <- system.file("extdata", package = package)
+  function(..., must_exist = TRUE, dbg = FALSE) {
 
+    lib.loc = .libPaths()
+    
+    packagePath <- find.package(package, lib.loc, quiet = FALSE, verbose = dbg)
+    
+    printIf(dbg, packagePath)
+    
+    extdata_dir <- system.file(
+      "extdata", 
+      package = package, 
+      lib.loc = lib.loc,
+      mustWork = TRUE
+    )
+    
+    if (!nzchar(extdata_dir)) {
+      stopFormatted(
+        "Could not determine path to 'extdata' folder of package '%s'",
+        package
+      )
+    }
+    
     if (must_exist) {
       safePath(extdata_dir, ...)
     } else {
@@ -27,6 +45,9 @@ createFunctionExtdataFile <- function(package)
 #' @param \dots parts of the file path to be passed to \code{\link{system.file}}
 #' @param must_exist if \code{TRUE} (the default) and the specified file does 
 #'   not exist, the program stops with an error message
+#' @param dbg if \code{TRUE} (the default is \code{FALSE}) debug messages are 
+#'   shown
+#' 
 #' @return path to file in the package installation folder in the R library
 #'   or "" if the path does not exist
 #' @return path to the specified file

--- a/man/extdataFile.Rd
+++ b/man/extdataFile.Rd
@@ -4,13 +4,16 @@
 \alias{extdataFile}
 \title{Path to File in Installed Package}
 \usage{
-extdataFile(..., must_exist = TRUE)
+extdataFile(..., must_exist = TRUE, dbg = FALSE)
 }
 \arguments{
 \item{\dots}{parts of the file path to be passed to \code{\link{system.file}}}
 
 \item{must_exist}{if \code{TRUE} (the default) and the specified file does 
 not exist, the program stops with an error message}
+
+\item{dbg}{if \code{TRUE} (the default is \code{FALSE}) debug messages are 
+shown}
 }
 \value{
 path to file in the package installation folder in the R library


### PR DESCRIPTION
`extdataFile()` returned "" and I could not find out why. The problem was that `system.file()` when being called without `lib.loc`, it looks for the package and somehow returned the packages's RStudio project folder instead of the folder where it is installed to. In that folder, there is no direct "extdata" folder. It is within the "inst" folder. Now, I set `lib.loc` explicitly to `.libPaths()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/kwb.utils/52)
<!-- Reviewable:end -->
